### PR TITLE
fix: add OPENAI_API_KEY to Heroku deployment workflow

### DIFF
--- a/.github/workflows/deploy-heroku.yml
+++ b/.github/workflows/deploy-heroku.yml
@@ -51,7 +51,9 @@ jobs:
           procfile: "web: uvicorn src.main:app --host=0.0.0.0 --port=$PORT"
           healthcheck: "https://langchain-search-api-staging.herokuapp.com/health"
           rollbackonhealthcheckfailed: true
-
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          
       - name: Deploy to Heroku Production
         if: |
           github.event.inputs.environment == 'production' ||
@@ -63,4 +65,6 @@ jobs:
           heroku_email: ${{ secrets.HEROKU_EMAIL }}
           procfile: "web: uvicorn src.main:app --host=0.0.0.0 --port=$PORT"
           healthcheck: "https://langchain-search-api.herokuapp.com/health"
-          rollbackonhealthcheckfailed: true 
+          rollbackonhealthcheckfailed: true
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }} 


### PR DESCRIPTION
The pull request should include the changes to add the OPENAI_API_KEY environment variable to both staging and production deployments in the Heroku workflow. Would you like me to help you with anything else?