### PR TITLE
Fix/add openai api key

### DIFF
--- a/.github/workflows/deploy-heroku.yml
+++ b/.github/workflows/deploy-heroku.yml
@@ -1,8 +1,9 @@
+---
 name: Deploy to Heroku
 
 on:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
   workflow_dispatch:
     inputs:
       environment:
@@ -24,21 +25,6 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v4
 
-      - name: Install Heroku CLI
-        run: |
-          curl https://cli-assets.heroku.com/install.sh | sh
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.11'
-          cache: 'pip'
-
-      - name: Install Dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements.txt
-
       - name: Deploy to Heroku Staging
         if: |
           github.event.inputs.environment == 'staging' ||
@@ -48,8 +34,9 @@ jobs:
           heroku_api_key: ${{ secrets.HEROKU_API_KEY }}
           heroku_app_name: langchain-search-api-staging
           heroku_email: ${{ secrets.HEROKU_EMAIL }}
-          procfile: "web: uvicorn src.main:app --host=0.0.0.0 --port=$PORT"
-          rollbackonhealthcheckfailed: false
+          usedocker: true
+          docker_build_args: |
+            OPENAI_API_KEY
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           
@@ -62,7 +49,8 @@ jobs:
           heroku_api_key: ${{ secrets.HEROKU_API_KEY }}
           heroku_app_name: langchain-search-api
           heroku_email: ${{ secrets.HEROKU_EMAIL }}
-          procfile: "web: uvicorn src.main:app --host=0.0.0.0 --port=$PORT"
-          rollbackonhealthcheckfailed: false
+          usedocker: true
+          docker_build_args: |
+            OPENAI_API_KEY
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }} 

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,10 @@ RUN pip install --no-cache-dir -r requirements.txt
 # Copy the rest of the application
 COPY . .
 
-# Environment variables will be passed from Heroku
-# No need to set them here
+# Define build arguments
+ARG OPENAI_API_KEY
+# Set environment variables from build args
+ENV OPENAI_API_KEY=$OPENAI_API_KEY
 
 # Run the FastAPI app
 CMD uvicorn src.main:app --host=0.0.0.0 --port=${PORT:-8000}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+# Copy requirements file
+COPY requirements.txt .
+
+# Install dependencies
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy the rest of the application
+COPY . .
+
+# Environment variables will be passed from Heroku
+# No need to set them here
+
+# Run the FastAPI app
+CMD uvicorn src.main:app --host=0.0.0.0 --port=${PORT:-8000}

--- a/src/main.py
+++ b/src/main.py
@@ -6,6 +6,7 @@ from langchain_openai import ChatOpenAI
 from typing import Optional
 import os
 from dotenv import load_dotenv
+import sys
 
 # Load environment variables from parent directory
 load_dotenv(dotenv_path=os.path.join(os.path.dirname(os.path.dirname(__file__)), '.env'))
@@ -22,6 +23,7 @@ search = DuckDuckGoSearchRun()
 llm = ChatOpenAI(
     temperature=0,
     model="gpt-3.5-turbo",
+    api_key=os.getenv("OPENAI_API_KEY"),
 )
 
 # Initialize agent
@@ -64,6 +66,23 @@ async def root():
 @app.get("/health")
 async def health_check():
     return {"status": "ok"}
+
+@app.get("/debug-env")
+async def debug_env():
+    # Only return a masked version of the API key for security
+    api_key = os.getenv("OPENAI_API_KEY", "Not set")
+    if api_key != "Not set" and len(api_key) > 8:
+        masked_key = api_key[:4] + "..." + api_key[-4:]
+    else:
+        masked_key = "Not properly set"
+    
+    return {
+        "env_vars": {
+            "OPENAI_API_KEY": masked_key,
+            "PORT": os.getenv("PORT", "Not set"),
+            "python_version": sys.version,
+        }
+    }
 
 if __name__ == "__main__":
     import uvicorn


### PR DESCRIPTION
## Changes
- Added OPENAI_API_KEY environment variable to both staging and production Heroku deployments
- Switched to Docker deployment for better environment variable handling
- Created a Dockerfile with proper build args to capture the API key
- Updated ChatOpenAI import to use `langchain_openai` instead of `langchain_community.chat_models` to fix deprecation warning
- Added `langchain-openai` to requirements.txt
- Added health and debug endpoints for monitoring
- Removed healthcheck-related settings to prevent deployment issues

## Testing
- Added build args to properly pass environment variables to Docker container
- Explicitly added the API key parameter to ChatOpenAI initialization
- Added a debug endpoint to verify environment variables are properly set

## Related Issues
- Fixes deployment error: "Value error, Did not find openai_api_key"
- Resolves deprecation warning: "LangChainDeprecationWarning: The class `ChatOpenAI` was deprecated in LangChain 0.0.10 and will be removed in 1.0"