### PR TITLE
fix: add Heroku CLI installation step back to workflow

### DIFF
--- a/.github/workflows/deploy-heroku.yml
+++ b/.github/workflows/deploy-heroku.yml
@@ -25,6 +25,10 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v4
 
+      - name: Install Heroku CLI
+        run: |
+          curl https://cli-assets.heroku.com/install.sh | sh
+
       - name: Deploy to Heroku Staging
         if: |
           github.event.inputs.environment == 'staging' ||


### PR DESCRIPTION
## Changes
- Added OPENAI_API_KEY environment variable to both staging and production Heroku deployments
- Switched to Docker deployment for better environment variable handling
- Created a Dockerfile with proper build args to capture the API key
- Updated ChatOpenAI import to use `langchain_openai` instead of `langchain_community.chat_models` to fix deprecation warning
- Added `langchain-openai` to requirements.txt
- Added health and debug endpoints for monitoring
- Removed healthcheck-related settings to prevent deployment issues
- Kept Heroku CLI installation step which is required for deployment

## Testing
- Added build args to properly pass environment variables to Docker container
- Explicitly added the API key parameter to ChatOpenAI initialization
- Added a debug endpoint to verify environment variables are properly set

## Related Issues
- Fixes deployment error: "Value error, Did not find openai_api_key"
- Resolves deprecation warning: "LangChainDeprecationWarning: The class `ChatOpenAI` was deprecated in LangChain 0.0.10 and will be removed in 1.0"