### PR TITLE
fix: update deployment to use Heroku container stack directly

### DIFF
--- a/.github/workflows/deploy-heroku.yml
+++ b/.github/workflows/deploy-heroku.yml
@@ -28,9 +28,12 @@ jobs:
       - name: Install Heroku CLI
         run: |
           curl https://cli-assets.heroku.com/install.sh | sh
+        continue-on-error: false
 
-      - name: Authenticate with Heroku
+      - name: Create Heroku Authentication file
         run: |
+          # Create Heroku authentication file
+          echo "Creating Heroku authentication file..."
           cat > ~/.netrc << EOF
           machine api.heroku.com
             login ${{ secrets.HEROKU_EMAIL }}
@@ -40,43 +43,105 @@ jobs:
             password ${{ secrets.HEROKU_API_KEY }}
           EOF
           chmod 600 ~/.netrc
+          echo "Authentication file created successfully."
+        continue-on-error: false
+
+      - name: Login to Heroku Container Registry
+        run: |
+          echo "Logging in to Heroku Container Registry..."
+          heroku container:login || {
+            echo "Failed to login to Heroku Container Registry"
+            exit 1
+          }
+          echo "Login successful."
+        continue-on-error: false
 
       - name: Deploy to Heroku Staging
         if: |
           github.event.inputs.environment == 'staging' ||
           (github.event_name == 'push' && github.ref == 'refs/heads/main')
         run: |
-          heroku container:login
+          echo "Starting deployment to staging environment..."
           
           # Check if app exists
-          if ! heroku apps:info langchain-search-api-staging &> /dev/null; then
-            echo "Creating new app with container stack"
-            heroku apps:create langchain-search-api-staging --stack=container
+          if heroku apps:info langchain-search-api-staging 2>&1 | grep -q "No app matches"; then
+            echo "App does not exist, creating new app with container stack..."
+            heroku apps:create langchain-search-api-staging --stack=container || {
+              echo "Failed to create app"
+              exit 1
+            }
+            echo "App created successfully."
+          else
+            echo "App already exists, continuing with deployment."
           fi
           
           # Set the environment variable
-          heroku config:set OPENAI_API_KEY="${{ secrets.OPENAI_API_KEY }}" --app langchain-search-api-staging
+          echo "Setting environment variables..."
+          heroku config:set OPENAI_API_KEY="${{ secrets.OPENAI_API_KEY }}" --app langchain-search-api-staging || {
+            echo "Failed to set environment variables"
+            exit 1
+          }
+          echo "Environment variables set successfully."
           
           # Deploy the container
-          heroku container:push web --app langchain-search-api-staging
-          heroku container:release web --app langchain-search-api-staging
+          echo "Pushing container to Heroku..."
+          heroku container:push web --app langchain-search-api-staging || {
+            echo "Failed to push container"
+            exit 1
+          }
+          echo "Container pushed successfully."
+          
+          echo "Releasing container..."
+          heroku container:release web --app langchain-search-api-staging || {
+            echo "Failed to release container"
+            exit 1
+          }
+          echo "Container released successfully."
+          
+          echo "Deployment to staging environment completed successfully."
+        continue-on-error: false
 
       - name: Deploy to Heroku Production
         if: |
           github.event.inputs.environment == 'production' ||
           (github.event_name == 'push' && github.ref == 'refs/heads/main')
         run: |
-          heroku container:login
+          echo "Starting deployment to production environment..."
           
           # Check if app exists
-          if ! heroku apps:info langchain-search-api &> /dev/null; then
-            echo "Creating new app with container stack"
-            heroku apps:create langchain-search-api --stack=container
+          if heroku apps:info langchain-search-api 2>&1 | grep -q "No app matches"; then
+            echo "App does not exist, creating new app with container stack..."
+            heroku apps:create langchain-search-api --stack=container || {
+              echo "Failed to create app"
+              exit 1
+            }
+            echo "App created successfully."
+          else
+            echo "App already exists, continuing with deployment."
           fi
           
           # Set the environment variable
-          heroku config:set OPENAI_API_KEY="${{ secrets.OPENAI_API_KEY }}" --app langchain-search-api
+          echo "Setting environment variables..."
+          heroku config:set OPENAI_API_KEY="${{ secrets.OPENAI_API_KEY }}" --app langchain-search-api || {
+            echo "Failed to set environment variables"
+            exit 1
+          }
+          echo "Environment variables set successfully."
           
           # Deploy the container
-          heroku container:push web --app langchain-search-api
-          heroku container:release web --app langchain-search-api 
+          echo "Pushing container to Heroku..."
+          heroku container:push web --app langchain-search-api || {
+            echo "Failed to push container"
+            exit 1
+          }
+          echo "Container pushed successfully."
+          
+          echo "Releasing container..."
+          heroku container:release web --app langchain-search-api || {
+            echo "Failed to release container"
+            exit 1
+          }
+          echo "Container released successfully."
+          
+          echo "Deployment to production environment completed successfully."
+        continue-on-error: false 

--- a/.github/workflows/deploy-heroku.yml
+++ b/.github/workflows/deploy-heroku.yml
@@ -29,32 +29,54 @@ jobs:
         run: |
           curl https://cli-assets.heroku.com/install.sh | sh
 
+      - name: Authenticate with Heroku
+        run: |
+          cat > ~/.netrc << EOF
+          machine api.heroku.com
+            login ${{ secrets.HEROKU_EMAIL }}
+            password ${{ secrets.HEROKU_API_KEY }}
+          machine git.heroku.com
+            login ${{ secrets.HEROKU_EMAIL }}
+            password ${{ secrets.HEROKU_API_KEY }}
+          EOF
+          chmod 600 ~/.netrc
+
       - name: Deploy to Heroku Staging
         if: |
           github.event.inputs.environment == 'staging' ||
           (github.event_name == 'push' && github.ref == 'refs/heads/main')
-        uses: akhileshns/heroku-deploy@v3.13.15
-        with:
-          heroku_api_key: ${{ secrets.HEROKU_API_KEY }}
-          heroku_app_name: langchain-search-api-staging
-          heroku_email: ${{ secrets.HEROKU_EMAIL }}
-          usedocker: true
-          docker_build_args: |
-            OPENAI_API_KEY
-        env:
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        run: |
+          heroku container:login
           
+          # Check if app exists
+          if ! heroku apps:info langchain-search-api-staging &> /dev/null; then
+            echo "Creating new app with container stack"
+            heroku apps:create langchain-search-api-staging --stack=container
+          fi
+          
+          # Set the environment variable
+          heroku config:set OPENAI_API_KEY="${{ secrets.OPENAI_API_KEY }}" --app langchain-search-api-staging
+          
+          # Deploy the container
+          heroku container:push web --app langchain-search-api-staging
+          heroku container:release web --app langchain-search-api-staging
+
       - name: Deploy to Heroku Production
         if: |
           github.event.inputs.environment == 'production' ||
           (github.event_name == 'push' && github.ref == 'refs/heads/main')
-        uses: akhileshns/heroku-deploy@v3.13.15
-        with:
-          heroku_api_key: ${{ secrets.HEROKU_API_KEY }}
-          heroku_app_name: langchain-search-api
-          heroku_email: ${{ secrets.HEROKU_EMAIL }}
-          usedocker: true
-          docker_build_args: |
-            OPENAI_API_KEY
-        env:
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }} 
+        run: |
+          heroku container:login
+          
+          # Check if app exists
+          if ! heroku apps:info langchain-search-api &> /dev/null; then
+            echo "Creating new app with container stack"
+            heroku apps:create langchain-search-api --stack=container
+          fi
+          
+          # Set the environment variable
+          heroku config:set OPENAI_API_KEY="${{ secrets.OPENAI_API_KEY }}" --app langchain-search-api
+          
+          # Deploy the container
+          heroku container:push web --app langchain-search-api
+          heroku container:release web --app langchain-search-api 

--- a/heroku.yml
+++ b/heroku.yml
@@ -1,0 +1,5 @@
+build:
+  docker:
+    web: Dockerfile
+  config:
+    OPENAI_API_KEY: ${OPENAI_API_KEY}


### PR DESCRIPTION
## Changes
- Fixed Docker deployment by configuring apps to use Heroku container stack
- Switched from using akhileshns/heroku-deploy action to direct Heroku CLI commands
- Added heroku.yml file for container stack configuration
- Properly set OPENAI_API_KEY environment variable in Heroku
- Updated ChatOpenAI import to use `langchain_openai` instead of `langchain_community.chat_models`
- Added `langchain-openai` to requirements.txt
- Added health and debug endpoints for monitoring

## Testing
- Fixed "Error: This command is for Docker apps only" by properly configuring the container stack
- Explicitly added the API key parameter to ChatOpenAI initialization
- Added a debug endpoint to verify environment variables are properly set

## Related Issues
- Fixes deployment error: "Value error, Did not find openai_api_key"
- Resolves deployment error: "This command is for Docker apps only"
- Resolves deprecation warning: "LangChainDeprecationWarning: The class `ChatOpenAI` was deprecated"